### PR TITLE
楽曲と合わせて座標情報も登録する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -266,6 +270,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   geocoder (= 1.7.0)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (~> 3.3)
   material_icons
   materialize-sass (~> 1.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,8 @@ body {
   margin: 0;
 }
 
+div.register_form {width: 50%}
+
 logo-img {
   object-fit: fill;
 }

--- a/app/controllers/coordinate_controller.rb
+++ b/app/controllers/coordinate_controller.rb
@@ -2,6 +2,7 @@ class CoordinateController < ApplicationController
     def find
         # find the nearest point from coordinate table
         @coodinates_in_area = Coordinate.near([coordinate_params["latitude"], coordinate_params["longitude"]], 5, units: :km)
+        p(@coodinates_in_area)
     end
 
     def create

--- a/app/controllers/song_controller.rb
+++ b/app/controllers/song_controller.rb
@@ -13,7 +13,7 @@ class SongController < ApplicationController
         @song.coordinate << coordinate
         @song.truncate_youtube_url()
         if @song.save
-            flash[:success] = "Your song registration successfully"
+            flash[:success] = "登録に成功しました"
             redirect_to "/"
         else
             redirect_to "/register"

--- a/app/controllers/song_controller.rb
+++ b/app/controllers/song_controller.rb
@@ -6,8 +6,10 @@ class SongController < ApplicationController
     def create
         @song = Song.new(url: song_coordinate_params["url"])
         @song.platform = 1 # Platform id of youtube
-        coordinate = Coordinate.new(latitude: song_coordinate_params["latitude"], 
-                                    longitude: song_coordinate_params["longitude"])
+        coordinate = Coordinate.new(latitude: song_coordinate_params["latitude"].to_f, 
+                                    longitude: song_coordinate_params["longitude"].to_f)
+        p("--------------")
+        p(coordinate)
         @song.coordinate << coordinate
         @song.truncate_youtube_url()
         if @song.save

--- a/app/controllers/song_controller.rb
+++ b/app/controllers/song_controller.rb
@@ -4,10 +4,10 @@ class SongController < ApplicationController
     end
 
     def create
-        @song = Song.new(song_params)
+        @song = Song.new(url: song_coordinate_params["url"])
         @song.platform = 1 # Platform id of youtube
-        # TODO: Get coordinate value from the form
-        coordinate = Coordinate.new(latitude: 50, longitude: 50)
+        coordinate = Coordinate.new(latitude: song_coordinate_params["latitude"], 
+                                    longitude: song_coordinate_params["longitude"])
         @song.coordinate << coordinate
         @song.truncate_youtube_url()
         if @song.save
@@ -19,8 +19,8 @@ class SongController < ApplicationController
     end
 
     private
-    def song_params
-      params.permit(:url)
+    def song_coordinate_params
+      params.permit(:url, :latitude, :longitude)
     end
 
 end

--- a/app/views/coordinate/find.html.erb
+++ b/app/views/coordinate/find.html.erb
@@ -2,15 +2,13 @@
 
 <ul>
   <% @coodinates_in_area.each do |point| %>
-    <h3>Point</h3>
-
-    <p>Latitude: <%= point.latitude %></p>
-    <p>Longitude: <%= point.longitude %></p>
+    <p>緯度: <%= point.latitude %></p>
+    <p>経度: <%= point.longitude %></p>
     <% if point.song.collect(&:url)[0] %>
       <p><%= youtube(point.song.collect(&:video_id)[0]) %></p>
-      <p>Youtube: <%= link_to point.song.collect(&:url)[0], point.song.collect(&:url)[0] %></p>
+      <p><%= link_to point.song.collect(&:url)[0], point.song.collect(&:url)[0] %></p>
     <% else %>
-      <p> No Youtube URL </p>
+      <p> Youtube URLが登録されていません </p>
     <% end %>
   
   <% end %>

--- a/app/views/song/register.html.erb
+++ b/app/views/song/register.html.erb
@@ -4,6 +4,10 @@
   <div>
     <%= form.label :url, "URL" %><br>
     <%= form.text_field :url %>
+    <%= form.label :latitude, "Latitude" %><br>
+    <%= form.text_field :latitude %>
+    <%= form.label :longitude, "Longitude" %><br>
+    <%= form.text_field :longitude %>
   </div>
 
   <br>

--- a/app/views/song/register.html.erb
+++ b/app/views/song/register.html.erb
@@ -4,9 +4,9 @@
   <div>
     <%= form.label :url, "URL" %><br>
     <%= form.text_field :url %>
-    <%= form.label :latitude, "Latitude" %><br>
+    <%= form.label :latitude, "緯度" %><br>
     <%= form.text_field :latitude %>
-    <%= form.label :longitude, "Longitude" %><br>
+    <%= form.label :longitude, "経度" %><br>
     <%= form.text_field :longitude %>
   </div>
 

--- a/app/views/song/register.html.erb
+++ b/app/views/song/register.html.erb
@@ -1,7 +1,10 @@
-<h2>ご当地ソングを登録してみよう</h2>
+<h2>ご当地ソングを登録しよう</h2>
 
+<%= link_to "Googleマップ", "https://google.co.jp/maps", class:"btn waves-effect waves-light", style: "color: black;" %>
+<%= link_to "YouTube", "https://youtube.com", class:"btn waves-effect waves-light", style: "color: black;"  %><br>
+<br>
 <%= form_with model: @song, url: :create, method: :post do |form| %>
-  <div>
+  <div class="register_form">
     <%= form.label :url, "URL" %><br>
     <%= form.text_field :url %>
     <%= form.label :latitude, "緯度" %><br>
@@ -11,7 +14,20 @@
   </div>
 
   <br>
-  <div>
-    <%= form.submit "登録" %>
-  </div>
+    <button class="btn waves-effect waves-light" type="submit" name="action" style= "font-weight: bold; color: black;">登録
+      <i class="material-icons right">send</i>
+    </button>
 <% end %>
+
+<script>
+    if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(showPosition);
+    } else {
+        window.alert('Geolocation API対応ブラウザでアクセスしてください。');
+    }
+
+    function showPosition(position) {
+        document.getElementById( "latitude" ).value = position.coords.latitude;
+        document.getElementById( "longitude" ).value = position.coords.longitude;
+    }
+</script>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,4 +1,5 @@
 <header class="title-container">
+  <div class="flash"><%= flash[:success] %></div>
   <h1 class="center-align title">あなたの街の<br>ご当地ソングを<br>探そう</h1>
   <%= form_with model: @coordinate, class:"form-wrap", url: :find, method: :get do |form| %>
     <%= form.text_field :latitude, type: "hidden" %>


### PR DESCRIPTION
## チケットへのリンク
https://github.com/z21001ms/team_project/issues/68
https://github.com/z21001ms/team_project/issues/70

## やったこと
- 楽曲登録時に座標情報を入力する
  - GPS有効時は現在地の座標が自動で入力される
- 登録画面の成形

## やらないこと
なし

## できるようになること（ユーザ目線）
やったことに同じ

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカルでの動作確認

## その他
見た目に関するレビューをいただきたいです
<img width="1369" alt="Screen Shot 2022-01-23 at 15 20 47" src="https://user-images.githubusercontent.com/34429021/150667307-c380df04-e98b-4aa3-9afc-684fb51ff326.png">



