### PR TITLE
remove jquery-rails from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,10 +97,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    jquery-rails (4.4.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -270,7 +266,6 @@ DEPENDENCIES
   capybara (>= 3.26)
   geocoder (= 1.7.0)
   jbuilder (~> 2.7)
-  jquery-rails
   listen (~> 3.3)
   material_icons
   materialize-sass (~> 1.0.0)


### PR DESCRIPTION
## チケットへのリンク
なし
## やったこと
デバッグ．不要なgem情報がGemfile.lockに残り，herokuでデプロイ失敗したので不要な情報を削除した

## やらないこと
なし

## できるようになること（ユーザ目線）
なし

## できなくなること（ユーザ目線）
なし

## 動作確認
ローカルでの確認

## その他
なし
